### PR TITLE
Remove outdated warning about vanilla profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Anyone, regardless of whether you are a customer of Mullvad VPN or not, can use 
 
 ## Features
 
-- Vanilla (vanilla/): Encrypted DNS, no blocking (dns.mullvad.net). TLS removed temporarily whilst it gets updated.
+- Vanilla (vanilla/): Encrypted DNS, no blocking (dns.mullvad.net)
 - Adblock (adblock/): Encrypted DNS which includes Ad-blocking and Tracker blocking (adblock.dns.mullvad.net)
 - Base (base/): Encrypted DNS which includes Ad-blocking, Tracker, and Malware blocking (base.dns.mullvad.net)
 - Family (family/): Encrypted DNS which includes Ad-blocking, Tracker, Malware, and Adult content blocking (family.dns.mullvad.net)


### PR DESCRIPTION
Issue #5 is resolved, so this warning is outdated. I verified the current binary has the right domain.

This should prevent future users from getting spooked like I did when I read that TLS was disabled and went trudging through git history and issues to see what the status of that was.

Thanks for providing these profiles and this service, by the way!